### PR TITLE
F outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,13 +81,13 @@ export2DSegmentOrigins = ['calcn_r', 'calcn_l', 'femur_r', 'femur_l', 'hand_r',
 # If True, right and left 3D GRFs (in this order) are exported. Set False or
 # do not pass as argument to not export those variables.
 exportGRFs = True
-# Export 3D segment origins.
-# Leave empty or do not pass as argument to not export those variables.
-export3DSegmentOrigins = ['pelvis', 'femur_r', 'tibia_r', 'talus_r', 'calcn_r',
-                          'toes_r', 'femur_l', 'tibia_l', 'talus_l', 'calcn_l',
-                          'toes_l', 'torso', 'humerus_r', 'ulna_r', 'radius_r', 
-                          'hand_r', 'humerus_l', 'ulna_l', 'radius_l', 
-                          'hand_l']
+# # Export 3D segment origins.
+# # Leave empty or do not pass as argument to not export those variables.
+# export3DSegmentOrigins = ['pelvis', 'femur_r', 'tibia_r', 'talus_r', 'calcn_r',
+#                           'toes_r', 'femur_l', 'tibia_l', 'talus_l', 'calcn_l',
+#                           'toes_l', 'torso', 'humerus_r', 'ulna_r', 'radius_r', 
+#                           'hand_r', 'humerus_l', 'ulna_l', 'radius_l', 
+#                           'hand_l']
 # Export GRMs.
 # If True, right and left 3D GRMs (in this order) are exported. Set False or
 # do not pass as argument to not export those variables.
@@ -95,10 +95,6 @@ exportGRMs = True
 
 # %% Generate external function.
 generateExternalFunction(pathOpenSimModel, pathExample, pathID, jointsOrder,
-                         coordinatesOrder, 
-                         export2DSegmentOrigins=export2DSegmentOrigins,
-                         exportGRFs=exportGRFs, 
-                         export3DSegmentOrigins=export3DSegmentOrigins,
-                         exportGRMs=exportGRMs,
+                         coordinatesOrder,
                          outputFilename=outputFilename,
                          compiler=compiler)

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ pathMain = os.getcwd()
 # Provide path to the directory where you want to save your results.
 pathExample = os.path.join(pathMain, 'examples')
 # Provide path to OpenSim model.
-pathOpenSimModel = os.path.join(pathExample, 'Hamner_modified.osim')
+pathOpenSimModel = os.path.join(pathExample, 'Hamner_modified_scaled.osim')
 # Provide path to the InverseDynamics folder.
 # To verify that what we did is correct, we compare torques returned by the
 # external function given some input data to torques returned by OpenSim's ID
@@ -64,7 +64,7 @@ coordinatesOrder = [
 
 # %% Optional user inputs.
 # Output file name (default is F).
-outputFilename = 'F'
+outputFilename = 'Hamner_modified_scaled'
 # Compiler (default is "Visual Studio 15 2017 Win64").
 compiler = "Visual Studio 15 2017 Win64"
 
@@ -83,7 +83,11 @@ export2DSegmentOrigins = ['calcn_r', 'calcn_l', 'femur_r', 'femur_l', 'hand_r',
 exportGRFs = True
 # Export 3D segment origins.
 # Leave empty or do not pass as argument to not export those variables.
-export3DSegmentOrigins = ['calcn_r', 'calcn_l']
+export3DSegmentOrigins = ['pelvis', 'femur_r', 'tibia_r', 'talus_r', 'calcn_r',
+                          'toes_r', 'femur_l', 'tibia_l', 'talus_l', 'calcn_l',
+                          'toes_l', 'torso', 'humerus_r', 'ulna_r', 'radius_r', 
+                          'hand_r', 'humerus_l', 'ulna_l', 'radius_l', 
+                          'hand_l']
 # Export GRMs.
 # If True, right and left 3D GRMs (in this order) are exported. Set False or
 # do not pass as argument to not export those variables.

--- a/main.py
+++ b/main.py
@@ -15,7 +15,13 @@
             - joint accelerations
         - OUTPUTS:
             - joint torques
-            - (optional) other variables exported from the model
+            - ground reaction forces
+            - ground reaction moments
+            - body origins
+            
+    This script also saves a dictionnary F_map with the indices of the
+    outputs of F. E.g., the left hip flexion index is given by 
+    F_map['residuals']['hip_flexion_l'].
             
     See concrete example of how the function F can be used here (TODO).        
     
@@ -28,11 +34,10 @@ from utilities import generateExternalFunction
 pathMain = os.getcwd()
 
 # %% User inputs.
-# Paths.
 # Provide path to the directory where you want to save your results.
 pathExample = os.path.join(pathMain, 'examples')
 # Provide path to OpenSim model.
-pathOpenSimModel = os.path.join(pathExample, 'Hamner_modified_scaled.osim')
+pathOpenSimModel = os.path.join(pathExample, 'Hamner_modified.osim')
 # Provide path to the InverseDynamics folder.
 # To verify that what we did is correct, we compare torques returned by the
 # external function given some input data to torques returned by OpenSim's ID
@@ -40,27 +45,6 @@ pathOpenSimModel = os.path.join(pathExample, 'Hamner_modified_scaled.osim')
 # of resulting torques differ, it means something went wrong when generating
 # the external function.
 pathID =  os.path.join(pathMain, 'InverseDynamics')
-# Joints and coordinates.
-# Provide the joints in the order you want to use when formulating your
-# trajectory optimization problem. You should include all joints (ie, include
-# also the weld joints). You can find the joint names in the .osim file.
-jointsOrder = ['ground_pelvis', 'hip_l', 'hip_r', 'knee_l', 'knee_r',
-               'ankle_l', 'ankle_r', 'subtalar_l', 'subtalar_r', 'mtp_l',
-               'mtp_r', 'back', 'acromial_l', 'acromial_r', 'elbow_l',
-               'elbow_r', 'radioulnar_l', 'radioulnar_r', 'radius_hand_l',
-               'radius_hand_r']
-# Provide the corresponding coordinates. Make sure the order match, eg. the
-# 'ground_pelvis' joint has 6 coordinates, namely 'pelvis_tilt', 'pelvis_list',
-# 'pelvis_rotation', 'pelvis_tx', 'pelvis_ty', 'pelvis_tz' in this order.
-coordinatesOrder = [
-    'pelvis_tilt', 'pelvis_list', 'pelvis_rotation', 'pelvis_tx', 'pelvis_ty', 
-    'pelvis_tz', 'hip_flexion_l', 'hip_adduction_l', 'hip_rotation_l', 
-    'hip_flexion_r', 'hip_adduction_r', 'hip_rotation_r', 'knee_angle_l', 
-    'knee_angle_r', 'ankle_angle_l', 'ankle_angle_r', 'subtalar_angle_l',
-    'subtalar_angle_r', 'mtp_angle_l', 'mtp_angle_r', 'lumbar_extension', 
-    'lumbar_bending', 'lumbar_rotation', 'arm_flex_l', 'arm_add_l', 
-    'arm_rot_l', 'arm_flex_r', 'arm_add_r', 'arm_rot_r', 'elbow_flex_l', 
-    'elbow_flex_r']
 
 # %% Optional user inputs.
 # Output file name (default is F).
@@ -68,33 +52,7 @@ outputFilename = 'Hamner_modified_scaled'
 # Compiler (default is "Visual Studio 15 2017 Win64").
 compiler = "Visual Studio 15 2017 Win64"
 
-# By default, the external function returns the joint torques. However, you
-# can also export other variables that you may want to use when formulating
-# your problem. Here, we provide a few examples of variables we typically use
-# in our problems. Note that the order matters, eg GRFs would be exported
-# before 3D segment origins before GRMs.
-# Export 2D segment origins.
-# Leave empty or do not pass as argument to not export those variables.
-export2DSegmentOrigins = ['calcn_r', 'calcn_l', 'femur_r', 'femur_l', 'hand_r',
-                          'hand_l', 'tibia_r', 'tibia_l', 'toes_r', 'toes_l']
-# Export GRFs.
-# If True, right and left 3D GRFs (in this order) are exported. Set False or
-# do not pass as argument to not export those variables.
-exportGRFs = True
-# # Export 3D segment origins.
-# # Leave empty or do not pass as argument to not export those variables.
-# export3DSegmentOrigins = ['pelvis', 'femur_r', 'tibia_r', 'talus_r', 'calcn_r',
-#                           'toes_r', 'femur_l', 'tibia_l', 'talus_l', 'calcn_l',
-#                           'toes_l', 'torso', 'humerus_r', 'ulna_r', 'radius_r', 
-#                           'hand_r', 'humerus_l', 'ulna_l', 'radius_l', 
-#                           'hand_l']
-# Export GRMs.
-# If True, right and left 3D GRMs (in this order) are exported. Set False or
-# do not pass as argument to not export those variables.
-exportGRMs = True
-
 # %% Generate external function.
 generateExternalFunction(pathOpenSimModel, pathExample, pathID,
                          outputFilename=outputFilename,
                          compiler=compiler)
-test = 0

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ exportGRFs = True
 exportGRMs = True
 
 # %% Generate external function.
-generateExternalFunction(pathOpenSimModel, pathExample, pathID, jointsOrder,
-                         coordinatesOrder,
+generateExternalFunction(pathOpenSimModel, pathExample, pathID,
                          outputFilename=outputFilename,
                          compiler=compiler)
+test = 0

--- a/utilities.py
+++ b/utilities.py
@@ -8,11 +8,7 @@ import importlib
 import pandas as pd
 
 def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
-                             jointsOrder, coordinatesOrder, 
-                             export2DSegmentOrigins=[],
-                             exportGRFs=False, 
-                             export3DSegmentOrigins=[],
-                             exportGRMs=False,
+                             jointsOrder, coordinatesOrder,
                              outputFilename='F',
                              compiler="Visual Studio 15 2017 Win64"):
     
@@ -25,6 +21,7 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
     model = opensim.Model(pathOpenSimModel)
     model.initSystem()
     bodySet = model.getBodySet()
+    nBodies = bodySet.getSize()
     jointSet = model.get_JointSet()
     nJoints = jointSet.getSize()
     geometrySet = model.get_ContactGeometrySet()
@@ -83,15 +80,16 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
         f.write('constexpr int NX = nCoordinates*2; \n')
         f.write('constexpr int NU = nCoordinates; \n')
         
-        nOutputs = nCoordinates
-        if export2DSegmentOrigins:
-            nOutputs += 2*len(export2DSegmentOrigins)
-        if exportGRFs:
-            nOutputs += 6
-        if exportGRMs:
-            nOutputs += 6
-        if export3DSegmentOrigins:
-            nOutputs += 3*len(export3DSegmentOrigins)
+        nOutputs = nCoordinates + 12 + 3*nBodies
+        # if export2DSegmentOrigins:
+        #     nOutputs += 2*len(export2DSegmentOrigins)
+        # if exportGRFs:
+        #     nOutputs += 6
+        # if exportGRMs:
+        #     nOutputs += 6
+        # if export3DSegmentOrigins:
+        #     nOutputs += 3*len(export3DSegmentOrigins)
+        # nOutputs += (
         f.write('constexpr int NR = %i; \n\n' % (nOutputs))
     
         f.write('template<typename T> \n')
@@ -758,71 +756,79 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
         f.write('\tmodel->getMatterSubsystem().calcResidualForceIgnoringConstraints(*state,\n')
         f.write('\t\t\tappliedMobilityForces, appliedBodyForces, knownUdot, residualMobilityForces);\n\n')
         
-        if export2DSegmentOrigins:
-            f.write('\t/// Segment origins.\n')
-            for segment in export2DSegmentOrigins:
-                f.write('\tVec3 %s_or = %s->getPositionInGround(*state);\n' % (segment, segment))
-            f.write('\n')
+        # if export2DSegmentOrigins:
+        #     f.write('\t/// Segment origins.\n')
+        #     for segment in export2DSegmentOrigins:
+        #         f.write('\tVec3 %s_or = %s->getPositionInGround(*state);\n' % (segment, segment))
+        #     f.write('\n')
             
-        if export3DSegmentOrigins:
-            f.write('\t/// Segment origins.\n')
-            for segment in export3DSegmentOrigins:
-                if not segment in export2DSegmentOrigins:
-                    f.write('\tVec3 %s_or = %s->getPositionInGround(*state);\n' % (segment, segment))
-            f.write('\n')            
+        # if export3DSegmentOrigins:
+        #     f.write('\t/// Segment origins.\n')
+        #     for segment in export3DSegmentOrigins:
+        #         if not segment in export2DSegmentOrigins:
+        #             f.write('\tVec3 %s_or = %s->getPositionInGround(*state);\n' % (segment, segment))
+        #     f.write('\n')
             
-        if exportGRFs:
-            f.write('\t/// Ground reaction forces.\n')
-            f.write('\tVec3 GRF_r(0), GRF_l(0);\n')
-            count = 0
-            for i in range(forceSet.getSize()):        
-                c_force_elt = forceSet.get(i)  
-                if c_force_elt.getConcreteClassName() == "SmoothSphereHalfSpaceForce":
-                    c_force_elt_name = c_force_elt.getName() 
-                    if c_force_elt_name[-2:] == "_r":
-                        f.write('\tGRF_r += GRF_%s[1];\n'  % (str(count)))
-                    elif c_force_elt_name[-2:] == "_l":
-                        f.write('\tGRF_l += GRF_%s[1];\n'  % (str(count)))
-                    else:
-                        raise ValueError("Cannot identify contact side")
-                    count += 1
-            f.write('\n')
+        # Get body origins.
+        f.write('\t/// Body origins.\n')
+        for i in range(nBodies):        
+            c_body = bodySet.get(i)
+            c_body_name = c_body.getName()
+            f.write('\tVec3 %s_or = %s->getPositionInGround(*state);\n' % (c_body_name, c_body_name))
+        f.write('\n')
             
-        if exportGRMs:
-            f.write('\t/// Ground reaction moments.\n')
-            f.write('\tVec3 GRM_r(0), GRM_l(0);\n')
-            f.write('\tVec3 normal(0, 1, 0);\n\n')
-            count = 0
-            geo1_frameNames = []
-            for i in range(forceSet.getSize()):        
-                c_force_elt = forceSet.get(i)  
-                if c_force_elt.getConcreteClassName() == "SmoothSphereHalfSpaceForce":
-                    c_force_elt_name = c_force_elt.getName() 
-                    socket1Name = c_force_elt.getSocketNames()[1]
-                    socket1 = c_force_elt.getSocket(socket1Name)
-                    socket1_obj = socket1.getConnecteeAsObject()
-                    socket1_objName = socket1_obj.getName()            
-                    geo1 = geometrySet.get(socket1_objName)
-                    geo1_frameName = geo1.getFrame().getName() 
+        # Get GRFs.
+        f.write('\t/// Ground reaction forces.\n')
+        f.write('\tVec3 GRF_r(0), GRF_l(0);\n')
+        count = 0
+        for i in range(forceSet.getSize()):        
+            c_force_elt = forceSet.get(i)  
+            if c_force_elt.getConcreteClassName() == "SmoothSphereHalfSpaceForce":
+                c_force_elt_name = c_force_elt.getName() 
+                if c_force_elt_name[-2:] == "_r":
+                    f.write('\tGRF_r += GRF_%s[1];\n'  % (str(count)))
+                elif c_force_elt_name[-2:] == "_l":
+                    f.write('\tGRF_l += GRF_%s[1];\n'  % (str(count)))
+                else:
+                    raise ValueError("Cannot identify contact side")
+                count += 1
+        f.write('\n')
+            
+        # Get GRMs.
+        f.write('\t/// Ground reaction moments.\n')
+        f.write('\tVec3 GRM_r(0), GRM_l(0);\n')
+        f.write('\tVec3 normal(0, 1, 0);\n\n')
+        count = 0
+        geo1_frameNames = []
+        for i in range(forceSet.getSize()):        
+            c_force_elt = forceSet.get(i)  
+            if c_force_elt.getConcreteClassName() == "SmoothSphereHalfSpaceForce":
+                c_force_elt_name = c_force_elt.getName() 
+                socket1Name = c_force_elt.getSocketNames()[1]
+                socket1 = c_force_elt.getSocket(socket1Name)
+                socket1_obj = socket1.getConnecteeAsObject()
+                socket1_objName = socket1_obj.getName()            
+                geo1 = geometrySet.get(socket1_objName)
+                geo1_frameName = geo1.getFrame().getName() 
+                
+                if not geo1_frameName in geo1_frameNames:
+                    f.write('\tSimTK::Transform TR_GB_%s = %s->getMobilizedBody().getBodyTransform(*state);\n' % (geo1_frameName, geo1_frameName))    
+                    geo1_frameNames.append(geo1_frameName)
                     
-                    if not geo1_frameName in geo1_frameNames:
-                        f.write('\tSimTK::Transform TR_GB_%s = %s->getMobilizedBody().getBodyTransform(*state);\n' % (geo1_frameName, geo1_frameName))    
-                        geo1_frameNames.append(geo1_frameName)
-                        
-                    f.write('\tVec3 %s_location_G = %s->findStationLocationInGround(*state, %s_location);\n' % (c_force_elt_name, geo1_frameName, c_force_elt_name))                
-                    f.write('\tVec3 %s_locationCP_G = %s_location_G - %s_radius * normal;\n' % (c_force_elt_name, c_force_elt_name, c_force_elt_name))
-                    f.write('\tVec3 locationCP_G_adj_%i = %s_locationCP_G - 0.5*%s_locationCP_G[1] * normal;\n' % (count, c_force_elt_name, c_force_elt_name))
-                    f.write('\tVec3 %s_locationCP_B = model->getGround().findStationLocationInAnotherFrame(*state, locationCP_G_adj_%i, *%s);\n' % (c_force_elt_name, count, geo1_frameName))
-                    f.write('\tVec3 GRM_%i = (TR_GB_%s*%s_locationCP_B) %% GRF_%s[1];\n' % (count, geo1_frameName, c_force_elt_name, str(count)))
-                    
-                    if c_force_elt_name[-2:] == "_r":
-                        f.write('\tGRM_r += GRM_%i;\n'  % (count))   
-                    elif c_force_elt_name[-2:] == "_l": 
-                        f.write('\tGRM_l += GRM_%i;\n'  % (count))   
-                    else:
-                        raise ValueError("Cannot identify contact side")
-                    f.write('\n')                   
-                    count += 1
+                f.write('\tVec3 %s_location_G = %s->findStationLocationInGround(*state, %s_location);\n' % (c_force_elt_name, geo1_frameName, c_force_elt_name))                
+                f.write('\tVec3 %s_locationCP_G = %s_location_G - %s_radius * normal;\n' % (c_force_elt_name, c_force_elt_name, c_force_elt_name))
+                f.write('\tVec3 locationCP_G_adj_%i = %s_locationCP_G - 0.5*%s_locationCP_G[1] * normal;\n' % (count, c_force_elt_name, c_force_elt_name))
+                f.write('\tVec3 %s_locationCP_B = model->getGround().findStationLocationInAnotherFrame(*state, locationCP_G_adj_%i, *%s);\n' % (c_force_elt_name, count, geo1_frameName))
+                f.write('\tVec3 GRM_%i = (TR_GB_%s*%s_locationCP_B) %% GRF_%s[1];\n' % (count, geo1_frameName, c_force_elt_name, str(count)))
+                
+                if c_force_elt_name[-2:] == "_r":
+                    f.write('\tGRM_r += GRM_%i;\n'  % (count))   
+                elif c_force_elt_name[-2:] == "_l": 
+                    f.write('\tGRM_l += GRM_%i;\n'  % (count))   
+                else:
+                    raise ValueError("Cannot identify contact side")
+                f.write('\n')                   
+                count += 1
         
         # Save dict pointing to which elements are returned by F and in which
         # order, such as to facilitate using F when formulating problem.
@@ -841,27 +847,42 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
         
         count_acc = 0
         
-        if export2DSegmentOrigins:
-            f.write('\t/// 2D segment origins.\n')
-            for c_seg, segment in enumerate(export2DSegmentOrigins):                    
-                f.write('\tres[0][NU + %i] = value<T>(%s_or[0]); \n' % (count_acc+c_seg*2, segment))
-                f.write('\tres[0][NU + %i] = value<T>(%s_or[2]); \n' % (count_acc+c_seg*2+1, segment))
-            count_acc += 2*len(export2DSegmentOrigins)                
-        if exportGRFs:
-            f.write('\t/// Ground reaction forces.\n')
-            f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRF_r[i]);\n' % (count_acc))
-            f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRF_l[i]);\n' % (count_acc+3))
-            count_acc += 6        
-        if export3DSegmentOrigins:
-            f.write('\t/// 3D segment origins.\n')
-            for c_seg, segment in enumerate(export3DSegmentOrigins):
-                f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(%s_or[i]);\n' % (count_acc+c_seg*3, segment))
-            count_acc += 3*len(export3DSegmentOrigins)
-        if exportGRMs:
-            f.write('\t/// Ground reaction moments.\n')
-            f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRM_r[i]);\n' % (count_acc))
-            f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRM_l[i]);\n' % (count_acc+3))
-            count_acc += 6
+        # Export GRFs
+        f.write('\t/// Ground reaction forces.\n')
+        f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRF_r[i]);\n' % (count_acc))
+        f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRF_l[i]);\n' % (count_acc+3))
+        F_map['GRFs'] = {}      
+        F_map['GRFs']['right'] = range(len(coordinates), len(coordinates)+3)
+        F_map['GRFs']['left'] = range(len(coordinates)+3, len(coordinates)+6)
+        count_acc += 6
+        
+        # Export GRMs
+        f.write('\t/// Ground reaction moments.\n')
+        f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRM_r[i]);\n' % (count_acc))
+        f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(GRM_l[i]);\n' % (count_acc+3))
+        F_map['GRMs'] = {}
+        F_map['GRMs']['right'] = range(len(coordinates)+count_acc, len(coordinates)+count_acc+3)
+        F_map['GRMs']['left'] = range(len(coordinates)+count_acc+3, len(coordinates)+count_acc+6)
+        count_acc += 6
+        
+        # Export body origins.
+        f.write('\t/// Body origins.\n')
+        F_map['body_origins'] = {}
+        for i in range(nBodies):        
+            c_body = bodySet.get(i)
+            c_body_name = c_body.getName()
+            f.write('\tfor (int i = 0; i < 3; ++i) res[0][i + NU + %i] = value<T>(%s_or[i]);\n' % (count_acc+i*3, c_body_name))
+            F_map['body_origins'][c_body_name] = range(len(coordinates)+count_acc+i*3, len(coordinates)+count_acc+i*3+3)
+        count_acc += 3*nBodies
+        
+        # if export2DSegmentOrigins:
+        #     f.write('\t/// 2D segment origins.\n')
+        #     for c_seg, segment in enumerate(export2DSegmentOrigins):                    
+        #         f.write('\tres[0][NU + %i] = value<T>(%s_or[0]); \n' % (count_acc+c_seg*2, segment))
+        #         f.write('\tres[0][NU + %i] = value<T>(%s_or[2]); \n' % (count_acc+c_seg*2+1, segment))
+        #     count_acc += 2*len(export2DSegmentOrigins)
+            
+        
             
         f.write('\n')
         f.write('\treturn 0;\n')


### PR DESCRIPTION
This PR cleans up the external function. There is no need to have different external functions for optimization and post-processing, since non-used outputs of the external function do not influence the optimization. It is therefore cleaner to have only one function.

This PR also fixes #2. There is now a dict F_map with the indices ogf the outputs of F.

This PR also removes the need to provide input joints and coordinates. Indeed, with the map it is now easier to do the mapping when formulating the problem.