### PR TITLE
Customjointt implementation and generic ID test

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Please cite this paper in your publications if you used OpenSimAD for simulation
   - Falisse A, et al. (2019) Rapid predictive simulations with complex musculoskeletal models suggest that diverse healthy and pathological human gaits can emerge from similar control strategies. J. R. Soc. Interface.162019040220190402. http://doi.org/10.1098/rsif.2019.0402
 
 ## Source code
-The libraries were compiled from [here](https://github.com/antoinefalisse/opensim-core/tree/AD-recorder-work-py-install).
+The OpenSimAD libraries were compiled from [here](https://github.com/antoinefalisse/opensim-core/tree/AD-recorder-work-py-install).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here we provide code and examples to generate external functions automatically g
 
 ### Example
   - run `main.py`
-      - You should get as output a few files in the example folder. Among them: `F.cpp` and `F.dll`. The .cpp file contains the source code of the external function, whereas the .dll file is the [dynamically linked library](https://web.casadi.org/docs/#casadi-s-external-function) that can be called when formulating your trajectory optimization problem.
+      - You should get as output a few files in the example folder. Among them: `F.cpp`, `F.dll`, and `F_map.npy`. The .cpp file contains the source code of the external function, the .dll file is the [dynamically linked library](https://web.casadi.org/docs/#casadi-s-external-function) that can be called when formulating your trajectory optimization problem, the .npy file is a dictionnary that describes the outputs of the external function (names and indices).
       - More details in the comments of `main.py` about what inputs are necessary and optional.
 
 ### Limitations

--- a/utilities.py
+++ b/utilities.py
@@ -582,7 +582,7 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
     # Create a dummy motion for ID
     DummyData = np.zeros((10, nCoordinates + 1))
     for coor in range(nCoordinates):
-        DummyData[:, coor + 1] = np.random.rand()+0.5
+        DummyData[:, coor + 1] = 0.05
     DummyData[:, 0] = np.linspace(0.01, 0.1, 10)
     labelsDummy = []
     labelsDummy.append("time")
@@ -638,7 +638,8 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
     for coor in range(nCoordinates):
         vecInput[coor * 2] = DummyData[0, coor + 1]
     ID_F = (F(vecInput)).full().flatten()[:nCoordinates]
-    # Assert we get the same torques.     
+    # Assert we get the same torques.
+    print('Max difference between ID solutions', np.max(np.abs(ID_osim - ID_F)))
     assert(np.max(np.abs(ID_osim - ID_F)) < 1e-6), "error F vs ID tool & osim"
 
 # %% Generate c-code with external function (and its Jacobian).

--- a/utilities.py
+++ b/utilities.py
@@ -582,7 +582,7 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
     # Create a dummy motion for ID
     DummyData = np.zeros((10, nCoordinates + 1))
     for coor in range(nCoordinates):
-        DummyData[:, coor + 1] = 0.05
+        DummyData[:, coor + 1] = np.random.rand()*0.05
     DummyData[:, 0] = np.linspace(0.01, 0.1, 10)
     labelsDummy = []
     labelsDummy.append("time")
@@ -634,9 +634,11 @@ def generateExternalFunction(pathOpenSimModel, outputDir, pathID,
     # Extract torques from external function.
     F = ca.external('F', os.path.join(outputDir, 
                                       outputFilename + '.dll'))
+    DefaultPos = storage2df(os.path.join(pathID,
+                                         "DummyDat.sto"), coordinates)
     vecInput = np.zeros((nCoordinates * 3, 1))
     for coor in range(nCoordinates):
-        vecInput[coor * 2] = DummyData[0, coor + 1]
+        vecInput[coor * 2] = DefaultPos.iloc[0][coordinates[coor]]
     ID_F = (F(vecInput)).full().flatten()[:nCoordinates]
     # Assert we get the same torques.
     print('Max difference between ID solutions', np.max(np.abs(ID_osim - ID_F)))


### PR DESCRIPTION
This PR handles:

- For loop implementation of a customjoint. The current code loops over the 6 DOFs in a customjoint instead and avoids the code repetition in the old version.
- Added PlanarJoint (this is typcially used in 2D models for the floating base)
- Added generic test for ID. The old version used a hard coded motion file (that only works for specific models) to compare the ID solutions with the ID-tool and the external function. This version creates a dummy motion file that depending on the coordinates in the model.