### PR TITLE
Update CMake minimum version to 3.10 in buildExternalFunction

### DIFF
--- a/buildExternalFunction/CMakeLists.txt
+++ b/buildExternalFunction/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.10)
 set (CMAKE_CXX_STANDARD 11)
 
 set(TARGET_NAME 


### PR DESCRIPTION
I got this error: 

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```
  
  I just bumped the minimum cmake to match the other CMakeLists.txt in the repo (with minimum 3.10). This seemed to fix the issue. 